### PR TITLE
Add env support for NewsData API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEWS_API_KEY=your_newsdata_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Konan
-EDA from the future.
+
+Example FastAPI and Dash application that displays stock prices from Yahoo Finance
+and retrieves related news via NewsData.io. Select a date range on the chart and
+click **Search News** to fetch headlines within that window (offset by one day).
+
+## Quick start
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Copy `.env.example` to `.env` and fill in your NewsData.io API key:
+
+```bash
+cp .env.example .env
+# edit .env and set NEWS_API_KEY
+```
+
+Run the FastAPI backend and Dash frontend:
+
+```bash
+uvicorn stock_data:app --reload &
+python dashboard.py
+```
+
+Open [http://localhost:8050](http://localhost:8050) to view the dashboard.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,101 @@
+import dash
+from dash import dcc, html
+from dash.dependencies import Input, Output, State
+import pandas as pd
+import requests
+
+app = dash.Dash(__name__)
+server = app.server
+
+app.layout = html.Div([
+    html.H2("Stock Dashboard"),
+    dcc.Dropdown(
+        id="ticker",
+        options=[{"label": x, "value": x} for x in ["AAPL", "MSFT", "GOOGL"]],
+        value="AAPL"
+    ),
+    dcc.RadioItems(
+        id="range",
+        options=[
+            {"label": "1M", "value": "1mo"},
+            {"label": "6M", "value": "6mo"},
+            {"label": "1Y", "value": "1y"},
+            {"label": "5Y", "value": "5y"}
+        ],
+        value="1y",
+        inline=True
+    ),
+    dcc.Graph(id="price-chart"),
+    html.Button("Search News", id="search-news-btn"),
+    html.Div(id="news-output", style={"marginTop": "20px"})
+])
+
+
+@app.callback(
+    Output("price-chart", "figure"),
+    Input("ticker", "value"),
+    Input("range", "value")
+)
+def update_chart(ticker, period):
+    url = f"http://localhost:8000/stock/{ticker}?period={period}"
+    df = pd.DataFrame(requests.get(url).json())
+
+    fig = {
+        "data": [{
+            "x": df["Date"],
+            "y": df["Close"],
+            "type": "scatter",
+            "mode": "lines",
+            "name": ticker
+        }],
+        "layout": {
+            "title": f"{ticker} Price History",
+            "xaxis": {
+                "rangeslider": {"visible": True},
+                "rangeselector": {
+                    "buttons": [
+                        {"count": 1, "label": "1M", "step": "month", "stepmode": "backward"},
+                        {"count": 6, "label": "6M", "step": "month", "stepmode": "backward"},
+                        {"count": 1, "label": "1Y", "step": "year", "stepmode": "backward"},
+                        {"count": 5, "label": "5Y", "step": "year", "stepmode": "backward"},
+                        {"step": "all"}
+                    ]
+                }
+            }
+        }
+    }
+    return fig
+
+
+@app.callback(
+    Output("news-output", "children"),
+    Input("search-news-btn", "n_clicks"),
+    State("price-chart", "relayoutData"),
+    State("ticker", "value")
+)
+def search_news(n_clicks, relayout_data, ticker):
+    if n_clicks is None or not relayout_data or "xaxis.range[0]" not in relayout_data:
+        return "Select a date range and click 'Search News'."
+
+    start_date = pd.to_datetime(relayout_data["xaxis.range[0]"]).date()
+    end_date = pd.to_datetime(relayout_data["xaxis.range[1]"]).date()
+
+    start_date -= pd.Timedelta(days=1)
+
+    news_url = f"http://localhost:8000/news/{ticker}?start={start_date}&end={end_date}"
+    news = requests.get(news_url).json()
+
+    if not news.get("results"):
+        return "No news found for that period."
+
+    items = []
+    for article in news["results"]:
+        items.append(html.Div([
+            html.A(article["title"], href=article["link"], target="_blank"),
+            html.Small(f" {article['pubDate']}")
+        ]))
+    return items
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+yfinance
+requests
+dash
+pandas
+python-dotenv

--- a/stock_data.py
+++ b/stock_data.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, Query, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+import yfinance as yf
+import requests
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+NEWS_API_KEY = os.getenv("NEWS_API_KEY")
+
+@app.get("/stock/{ticker}")
+def get_stock(ticker: str, period: str = "1y", interval: str = "1d"):
+    data = yf.download(ticker, period=period, interval=interval)
+    data.reset_index(inplace=True)
+    return JSONResponse(data.to_dict(orient="records"))
+
+@app.get("/news/{company}")
+def get_news(company: str, start: str = Query(...), end: str = Query(...)):
+    if not NEWS_API_KEY:
+        raise HTTPException(status_code=500, detail="NEWS_API_KEY not configured")
+
+    url = "https://newsdata.io/api/1/news"
+    params = {
+        "apikey": NEWS_API_KEY,
+        "q": company,
+        "language": "en",
+        "category": "business",
+        "from_date": start,
+        "to_date": end,
+    }
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
## Summary
- read NEWS_API_KEY from `.env`
- document setup of environment file
- add example env file and ignore real secrets
- include python-dotenv in requirements

## Testing
- `python -m py_compile stock_data.py dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_6880f1d01e78832989e6f7f86e0d37db