### PR TITLE
Add dashboard mount to FastAPI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ cp .env.example .env
 # edit .env and set NEWS_API_KEY
 ```
 
-Run the FastAPI backend and Dash frontend:
+Run the combined FastAPI and Dash server:
 
 ```bash
-uvicorn stock_data:app --reload &
-python dashboard.py
+uvicorn stock_data:app --reload
 ```
 
-Open [http://localhost:8050](http://localhost:8050) to view the dashboard.
+Open [http://localhost:8000/dashboard](http://localhost:8000/dashboard) to view the dashboard.

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,10 +4,10 @@ from dash.dependencies import Input, Output, State
 import pandas as pd
 import requests
 
-app = dash.Dash(__name__)
-server = app.server
+dash_app = dash.Dash(__name__)
+server = dash_app.server
 
-app.layout = html.Div([
+dash_app.layout = html.Div([
     html.H2("Stock Dashboard"),
     dcc.Dropdown(
         id="ticker",
@@ -31,7 +31,7 @@ app.layout = html.Div([
 ])
 
 
-@app.callback(
+@dash_app.callback(
     Output("price-chart", "figure"),
     Input("ticker", "value"),
     Input("range", "value")
@@ -67,7 +67,7 @@ def update_chart(ticker, period):
     return fig
 
 
-@app.callback(
+@dash_app.callback(
     Output("news-output", "children"),
     Input("search-news-btn", "n_clicks"),
     State("price-chart", "relayoutData"),
@@ -98,4 +98,4 @@ def search_news(n_clicks, relayout_data, ticker):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    dash_app.run_server(debug=True)

--- a/stock_data.py
+++ b/stock_data.py
@@ -1,14 +1,19 @@
 from fastapi import FastAPI, Query, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, HTMLResponse
+from fastapi.middleware.wsgi import WSGIMiddleware
 import yfinance as yf
 import requests
 import os
 from dotenv import load_dotenv
+from dashboard import dash_app
 
 load_dotenv()
 
 app = FastAPI()
+
+# Mount the Dash dashboard at /dashboard
+app.mount("/dashboard", WSGIMiddleware(dash_app.server))
 
 app.add_middleware(
     CORSMiddleware,
@@ -18,6 +23,27 @@ app.add_middleware(
 )
 
 NEWS_API_KEY = os.getenv("NEWS_API_KEY")
+
+
+@app.get("/", response_class=HTMLResponse)
+def read_root():
+    """Display basic usage instructions."""
+    return """
+    <html>
+        <head><title>Konan API</title></head>
+        <body>
+            <h1>Konan Stock Dashboard API</h1>
+            <p>This service provides stock prices and news data for the Dash dashboard.</p>
+            <h2>Getting started</h2>
+            <ol>
+                <li>Install dependencies with <code>pip install -r requirements.txt</code></li>
+                <li>Copy <code>.env.example</code> to <code>.env</code> and add your NewsData.io API key.</li>
+                <li>Run the server with <code>uvicorn stock_data:app --reload</code></li>
+                <li>Open <a href='http://localhost:8000/dashboard'>http://localhost:8000/dashboard</a> to view the dashboard.</li>
+            </ol>
+        </body>
+    </html>
+    """
 
 @app.get("/stock/{ticker}")
 def get_stock(ticker: str, period: str = "1y", interval: str = "1d"):


### PR DESCRIPTION
## Summary
- mount Dash dashboard within FastAPI
- update root page instructions
- simplify README to use single server

## Testing
- `python -m py_compile stock_data.py dashboard.py`
- `uvicorn stock_data:app --port 8000 --workers 1 --timeout-keep-alive 0` and `curl http://127.0.0.1:8000/dashboard/`

------
https://chatgpt.com/codex/tasks/task_e_6880fba39d6883299c3518ed716abc32